### PR TITLE
Update GitHub action to run on PR

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -7,7 +7,7 @@
 name: Deploy To Github Pages
 
 on:
-  push:
+  pull_request:
     branches:
       - master
       - main

--- a/src/components/Banner/Banner.js
+++ b/src/components/Banner/Banner.js
@@ -13,7 +13,7 @@ const Banner = (props) => {
 					height="100%"
 				/>
 				<p>DePaul University</p>
-				<p>Dates TBA </p>
+				<p>Dates Coming Soon!</p>
 				<p>24 hours</p>
 			</div>
 			<br/>


### PR DESCRIPTION
The publish action now runs on a PR to main/master instead of push.